### PR TITLE
Add GitHub Actions workflow for Docker image build and push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Build and Push Docker Image
 
+permissions:
+  packages: write
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,44 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.pusher != null)
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image tag
+        id: tag
+        run: |
+          echo "TAG=$(date +'%y%m%d_%H%M')" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: |
+          go test ./...
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ env.TAG }}

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ A separate GitHub Action workflow automatically builds and pushes a Docker image
 
 - **Image Tag Format:** `yyMMdd_HHmm` (e.g., `250525_1530` for May 25, 2025, 15:30 UTC)
 - **Registry:** `ghcr.io/<owner>/<repo>:<tag>`
-- **Manual Trigger:** Go to the [Actions tab](../../actions) and select the "Build and Push Docker Image" workflow, then click "Run workflow".
+- **Manual Trigger:** Go to the [Actions tab](/ckrowiorsch/langsmith-exporter/actions) and select the "Build and Push Docker Image" workflow, then click "Run workflow".
 
 ### Example: Using the Latest Image
 

--- a/README.md
+++ b/README.md
@@ -81,3 +81,24 @@ spec:
 ```
 
 The exporter will then be available at `http://<service-ip>:8080/metrics` and can be scraped by Prometheus.
+
+## GitHub Actions: Docker Image Build & Push
+
+A separate GitHub Action workflow automatically builds and pushes a Docker image to the GitHub Container Registry (`ghcr.io`) **when a pull request is merged into `main` and all tests are successful**. You can also trigger this workflow manually from the GitHub Actions tab.
+
+- **Image Tag Format:** `yyMMdd_HHmm` (e.g., `250525_1530` for May 25, 2025, 15:30 UTC)
+- **Registry:** `ghcr.io/<owner>/<repo>:<tag>`
+- **Manual Trigger:** Go to the [Actions tab](../../actions) and select the "Build and Push Docker Image" workflow, then click "Run workflow".
+
+### Example: Using the Latest Image
+
+Update your Kubernetes or Docker deployment to use the latest image tag:
+
+```yaml
+containers:
+  - name: exporter
+    image: ghcr.io/<owner>/<repo>:<tag>
+    # ...
+```
+
+See `.github/workflows/docker-image.yml` for details.


### PR DESCRIPTION
This PR adds a workflow that builds and pushes a Docker image to GHCR when a PR is merged into main or the workflow is triggered manually.

- Image tag format: yyMMdd_HHmm
-  Pushes to ghcr.io
- Only runs if tests are successful

Closes #12.