### PR TITLE
fix: ensure docker image name is always lowercase in GitHub Action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,6 +34,7 @@ jobs:
         id: tag
         run: |
           echo "TAG=$(date +'%y%m%d_%H%M')" >> $GITHUB_ENV
+          echo "REPO_LC=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Run tests
         run: |
@@ -44,4 +45,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ env.TAG }}
+          tags: ghcr.io/${{ env.REPO_LC }}:${{ env.TAG }}


### PR DESCRIPTION
This PR ensures that the Docker image name is always lowercase in the GitHub Action.\n\nCloses #14.