### PR TITLE
Update Golang-Container auf 1.24.1-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the official Golang image for building
-FROM golang:1.21-alpine AS builder
+FROM golang:1.24.1-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Das Dockerfile verwendet jetzt golang:1.24.1-alpine als Basis-Image.